### PR TITLE
Add descriptions to all the pages that don't have them

### DIFF
--- a/content/pages/bladesmithing.md
+++ b/content/pages/bladesmithing.md
@@ -1,6 +1,7 @@
 ---
-title: "Bladesmithing"
+title: 'Bladesmithing'
 date: 2021-09-15T18:08:01-05:00
+description: 'Resources relating to bladesmithing'
 ---
 
 [Blade steels and heat treatment](https://knifesteelnerds.com/getting-started/)

--- a/content/pages/bloom_steel.md
+++ b/content/pages/bloom_steel.md
@@ -1,6 +1,7 @@
 ---
-title: "Bloom Steel"
+title: 'Bloom Steel'
 date: 2021-09-15T18:09:37-05:00
+description: 'Resources relating to the creation of bloom steel, also known as hearth steel'
 ---
 
 

--- a/content/pages/books.md
+++ b/content/pages/books.md
@@ -1,6 +1,7 @@
 ---
-title: "Books"
+title: 'Books'
 date: 2021-09-15T17:53:20-05:00
+description: 'A list of recommended reading materials'
 tags:
 - education
 ---

--- a/content/pages/charts.md
+++ b/content/pages/charts.md
@@ -1,6 +1,7 @@
 ---
-title: "Charts"
+title: 'Charts'
 date: 2021-09-15T19:12:30-05:00
+description: 'A selection of useful reference charts'
 ---
 
 [European Steel and Alloy Grades / Numbers and equivalents](http://steelnumber.com/)

--- a/content/pages/equipment.md
+++ b/content/pages/equipment.md
@@ -1,6 +1,7 @@
 ---
 title: 'Equipment and Material Recommendations'
 date: 2021-09-15T17:46:45-05:00
+description: 'Our recommendations for basic blacksmithing equipment and materials'
 tags:
 - beginner
 - equipment

--- a/content/pages/lessons.md
+++ b/content/pages/lessons.md
@@ -1,6 +1,7 @@
 ---
-title: "Lessons"
+title: 'Lessons'
 date: 2021-09-15T17:52:09-05:00
+description: 'Self-directed resources for furthering your blacksmithing education'
 tags:
 - beginner
 - education

--- a/content/pages/media.md
+++ b/content/pages/media.md
@@ -1,6 +1,7 @@
 ---
-title: "Media"
+title: 'Media'
 date: 2021-09-15T20:23:56-05:00
+description: 'Assorted external resources and media'
 tags:
 - education
 ---

--- a/content/pages/metallurgy.md
+++ b/content/pages/metallurgy.md
@@ -1,6 +1,7 @@
 ---
-title: "Metallurgy"
+title: 'Metallurgy'
 date: 2021-09-15T17:48:05-05:00
+description: 'Resources relating to general metallurgy'
 tags:
 - 'heat treat'
 ---

--- a/content/pages/safety.md
+++ b/content/pages/safety.md
@@ -2,6 +2,7 @@
 title: 'Watch This First!'
 date: 2021-09-18T00:03:19-05:00
 weight: 1
+description: 'Crucial safety information for new and aspiring blacksmiths'
 tags:
 - beginner
 - safety

--- a/content/pages/vendors.md
+++ b/content/pages/vendors.md
@@ -1,6 +1,7 @@
 ---
 title: 'Vendors'
 date: 2021-09-15T17:52:43-05:00
+description: 'A list of recommended blacksmithing suppliers'
 tags:
 - equipment
 ---


### PR DESCRIPTION
The description field makes the URL summary (shown in Discord when a link is shared) much more useful and readable. This PR adds descriptions for all the pages that didn't have them. A future PR will include a precommit hook that checks for missing descriptions.